### PR TITLE
Add Ukrainian,Afrikaans,Greek,Thai,etc language support #1

### DIFF
--- a/BibleTalkAI.LanguageOptions/BibleTalkAI.LanguageOptions.csproj
+++ b/BibleTalkAI.LanguageOptions/BibleTalkAI.LanguageOptions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageVersion>1.0.0</PackageVersion>
+    <PackageVersion>1.1.0</PackageVersion>
     <Description>Types for language preference options for BibleTalkAI.com</Description>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/BibleTalkAI.LanguageOptions/LanguagePreferences.cs
+++ b/BibleTalkAI.LanguageOptions/LanguagePreferences.cs
@@ -8,11 +8,12 @@ public static class LanguagePreferences
 
     static LanguagePreferences()
     {
-        int primeNumberCapacity = 31;
+        int primeNumberCapacity = 47;
 
-        // Lithuanian static readonly missing from Twilio.TwiML.Voice.Say.LanguageEnum
-        Say.LanguageEnum ltlt = new();
-        ltlt.FromString("lt-LT");
+        // Lithuanian,Basque,Galician static readonly missing from Twilio.TwiML.Voice.Say.LanguageEnum
+        Say.LanguageEnum ltlt = SayLanguageEnum("lt-LT"); // Lithuanian
+        Say.LanguageEnum eues = SayLanguageEnum("eu-ES"); // Basque
+        Say.LanguageEnum gles = SayLanguageEnum("gl-ES"); // Galician
 
         Languages = new Dictionary<int, LanguagePreference>(primeNumberCapacity)
         {
@@ -263,6 +264,134 @@ public static class LanguagePreferences
                 SayLanguage = Say.LanguageEnum.LvLv,
                 LanguageNameInEnglish = "Latvian"
             },
+            [32] = new LanguagePreference
+            {
+                LanguagePreferenceOption = 32,
+                GatherLanguage = Gather.LanguageEnum.AfZa,
+                SayVoice = Say.VoiceEnum.GoogleAfZaStandardA,
+                SayLanguage = Say.LanguageEnum.AfZa,
+                LanguageNameInEnglish = "Afrikaans"
+            },
+            [33] = new LanguagePreference
+            {
+                LanguagePreferenceOption = 33,
+                GatherLanguage = Gather.LanguageEnum.EuEs,
+                SayVoice = Say.VoiceEnum.GoogleEuEsStandardA,
+                SayLanguage = eues,
+                LanguageNameInEnglish = "Basque"
+            },
+            [34] = new LanguagePreference
+            {
+                LanguagePreferenceOption = 34,
+                GatherLanguage = Gather.LanguageEnum.BgBg,
+                SayVoice = Say.VoiceEnum.GoogleBgBgStandardA,
+                SayLanguage = Say.LanguageEnum.BgBg,
+                LanguageNameInEnglish = "Bulgarian"
+            },
+            [35] = new LanguagePreference
+            {
+                LanguagePreferenceOption = 35,
+                GatherLanguage = Gather.LanguageEnum.CaEs,
+                SayVoice = Say.VoiceEnum.PollyArletNeural,
+                SayLanguage = Say.LanguageEnum.CaEs,
+                LanguageNameInEnglish = "Catalan"
+            },
+            [36] = new LanguagePreference
+            {
+                LanguagePreferenceOption = 36,
+                GatherLanguage = Gather.LanguageEnum.CsCz,
+                SayVoice = Say.VoiceEnum.GoogleCsCzWavenetA,
+                SayLanguage = Say.LanguageEnum.CsCz,
+                LanguageNameInEnglish = "Czech"
+            },
+            [37] = new LanguagePreference
+            {
+                LanguagePreferenceOption = 37,
+                GatherLanguage = Gather.LanguageEnum.FiFi,
+                SayVoice = Say.VoiceEnum.PollySuviNeural,
+                SayLanguage = Say.LanguageEnum.FiFi,
+                LanguageNameInEnglish = "Finnish"
+            },
+            [38] = new LanguagePreference
+            {
+                LanguagePreferenceOption = 38,
+                GatherLanguage = Gather.LanguageEnum.GlEs,
+                SayVoice = Say.VoiceEnum.GoogleGlEsStandardA,
+                SayLanguage = gles,
+                LanguageNameInEnglish = "Galician"
+            },
+            [39] = new LanguagePreference
+            {
+                LanguagePreferenceOption = 39,
+                GatherLanguage = Gather.LanguageEnum.ElGr,
+                SayVoice = Say.VoiceEnum.GoogleElGrWavenetA,
+                SayLanguage = Say.LanguageEnum.ElGr,
+                LanguageNameInEnglish = "Greek"
+            },
+            [40] = new LanguagePreference
+            {
+                LanguagePreferenceOption = 40,
+                GatherLanguage = Gather.LanguageEnum.HuHu,
+                SayVoice = Say.VoiceEnum.GoogleHuHuWavenetA,
+                SayLanguage = Say.LanguageEnum.HuHu,
+                LanguageNameInEnglish = "Hungarian"
+            },
+            [41] = new LanguagePreference
+            {
+                LanguagePreferenceOption = 41,
+                GatherLanguage = Gather.LanguageEnum.IsIs,
+                SayVoice = Say.VoiceEnum.PollyKarl,
+                SayLanguage = Say.LanguageEnum.IsIs,
+                LanguageNameInEnglish = "Icelandic"
+            },
+            [42] = new LanguagePreference
+            {
+                LanguagePreferenceOption = 42,
+                GatherLanguage = Gather.LanguageEnum.RoRo,
+                SayVoice = Say.VoiceEnum.GoogleRoRoWavenetA,
+                SayLanguage = Say.LanguageEnum.RoRo,
+                LanguageNameInEnglish = "Romanian"
+            },
+            [43] = new LanguagePreference
+            {
+                LanguagePreferenceOption = 43,
+                GatherLanguage = Gather.LanguageEnum.SrRs,
+                SayVoice = Say.VoiceEnum.GoogleSrRsStandardA,
+                SayLanguage = Say.LanguageEnum.SrRs,
+                LanguageNameInEnglish = "Serbian"
+            },
+            [44] = new LanguagePreference
+            {
+                LanguagePreferenceOption = 44,
+                GatherLanguage = Gather.LanguageEnum.SkSk,
+                SayVoice = Say.VoiceEnum.GoogleSkSkWavenetA,
+                SayLanguage = Say.LanguageEnum.SkSk,
+                LanguageNameInEnglish = "Slovak"
+            },
+            [45] = new LanguagePreference
+            {
+                LanguagePreferenceOption = 45,
+                GatherLanguage = Gather.LanguageEnum.ThTh,
+                SayVoice = Say.VoiceEnum.GoogleThThStandardA,
+                SayLanguage = Say.LanguageEnum.ThTh,
+                LanguageNameInEnglish = "Thai"
+            },
+            [46] = new LanguagePreference
+            {
+                LanguagePreferenceOption = 46,
+                GatherLanguage = Gather.LanguageEnum.UkUa,
+                SayVoice = Say.VoiceEnum.GoogleUkUaWavenetA,
+                SayLanguage = Say.LanguageEnum.UkUa,
+                LanguageNameInEnglish = "Ukrainian"
+            },
         };
+
+    }
+
+    private static Say.LanguageEnum SayLanguageEnum(string lang)
+    {
+        Say.LanguageEnum sayLanguage = new();
+        sayLanguage.FromString(lang);
+        return sayLanguage;
     }
 }

--- a/README.md
+++ b/README.md
@@ -245,4 +245,124 @@ The following options are supported:
     SayLanguage = Say.LanguageEnum.LvLv,
     LanguageNameInEnglish = "Latvian"
 },
+[32] = new LanguagePreference
+{
+    LanguagePreferenceOption = 32,
+    GatherLanguage = Gather.LanguageEnum.AfZa,
+    SayVoice = Say.VoiceEnum.GoogleAfZaStandardA,
+    SayLanguage = Say.LanguageEnum.AfZa,
+    LanguageNameInEnglish = "Afrikaans"
+},
+[33] = new LanguagePreference
+{
+    LanguagePreferenceOption = 33,
+    GatherLanguage = Gather.LanguageEnum.EuEs,
+    SayVoice = Say.VoiceEnum.GoogleEuEsStandardA,
+    SayLanguage = eues,
+    LanguageNameInEnglish = "Basque"
+},
+[34] = new LanguagePreference
+{
+    LanguagePreferenceOption = 34,
+    GatherLanguage = Gather.LanguageEnum.BgBg,
+    SayVoice = Say.VoiceEnum.GoogleBgBgStandardA,
+    SayLanguage = Say.LanguageEnum.BgBg,
+    LanguageNameInEnglish = "Bulgarian"
+},
+[35] = new LanguagePreference
+{
+    LanguagePreferenceOption = 35,
+    GatherLanguage = Gather.LanguageEnum.CaEs,
+    SayVoice = Say.VoiceEnum.PollyArletNeural,
+    SayLanguage = Say.LanguageEnum.CaEs,
+    LanguageNameInEnglish = "Catalan"
+},
+[36] = new LanguagePreference
+{
+    LanguagePreferenceOption = 36,
+    GatherLanguage = Gather.LanguageEnum.CsCz,
+    SayVoice = Say.VoiceEnum.GoogleCsCzWavenetA,
+    SayLanguage = Say.LanguageEnum.CsCz,
+    LanguageNameInEnglish = "Czech"
+},
+[37] = new LanguagePreference
+{
+    LanguagePreferenceOption = 37,
+    GatherLanguage = Gather.LanguageEnum.FiFi,
+    SayVoice = Say.VoiceEnum.PollySuviNeural,
+    SayLanguage = Say.LanguageEnum.FiFi,
+    LanguageNameInEnglish = "Finnish"
+},
+[38] = new LanguagePreference
+{
+    LanguagePreferenceOption = 38,
+    GatherLanguage = Gather.LanguageEnum.GlEs,
+    SayVoice = Say.VoiceEnum.GoogleGlEsStandardA,
+    SayLanguage = gles,
+    LanguageNameInEnglish = "Galician"
+},
+[39] = new LanguagePreference
+{
+    LanguagePreferenceOption = 39,
+    GatherLanguage = Gather.LanguageEnum.ElGr,
+    SayVoice = Say.VoiceEnum.GoogleElGrWavenetA,
+    SayLanguage = Say.LanguageEnum.ElGr,
+    LanguageNameInEnglish = "Greek"
+},
+[40] = new LanguagePreference
+{
+    LanguagePreferenceOption = 40,
+    GatherLanguage = Gather.LanguageEnum.HuHu,
+    SayVoice = Say.VoiceEnum.GoogleHuHuWavenetA,
+    SayLanguage = Say.LanguageEnum.HuHu,
+    LanguageNameInEnglish = "Hungarian"
+},
+[41] = new LanguagePreference
+{
+    LanguagePreferenceOption = 41,
+    GatherLanguage = Gather.LanguageEnum.IsIs,
+    SayVoice = Say.VoiceEnum.PollyKarl,
+    SayLanguage = Say.LanguageEnum.IsIs,
+    LanguageNameInEnglish = "Icelandic"
+},
+[42] = new LanguagePreference
+{
+    LanguagePreferenceOption = 42,
+    GatherLanguage = Gather.LanguageEnum.RoRo,
+    SayVoice = Say.VoiceEnum.GoogleRoRoWavenetA,
+    SayLanguage = Say.LanguageEnum.RoRo,
+    LanguageNameInEnglish = "Romanian"
+},
+[43] = new LanguagePreference
+{
+    LanguagePreferenceOption = 43,
+    GatherLanguage = Gather.LanguageEnum.SrRs,
+    SayVoice = Say.VoiceEnum.GoogleSrRsStandardA,
+    SayLanguage = Say.LanguageEnum.SrRs,
+    LanguageNameInEnglish = "Serbian"
+},
+[44] = new LanguagePreference
+{
+    LanguagePreferenceOption = 44,
+    GatherLanguage = Gather.LanguageEnum.SkSk,
+    SayVoice = Say.VoiceEnum.GoogleSkSkWavenetA,
+    SayLanguage = Say.LanguageEnum.SkSk,
+    LanguageNameInEnglish = "Slovak"
+},
+[45] = new LanguagePreference
+{
+    LanguagePreferenceOption = 45,
+    GatherLanguage = Gather.LanguageEnum.ThTh,
+    SayVoice = Say.VoiceEnum.GoogleThThStandardA,
+    SayLanguage = Say.LanguageEnum.ThTh,
+    LanguageNameInEnglish = "Thai"
+},
+[46] = new LanguagePreference
+{
+    LanguagePreferenceOption = 46,
+    GatherLanguage = Gather.LanguageEnum.UkUa,
+    SayVoice = Say.VoiceEnum.GoogleUkUaWavenetA,
+    SayLanguage = Say.LanguageEnum.UkUa,
+    LanguageNameInEnglish = "Ukrainian"
+},
 ```


### PR DESCRIPTION
Adds language support for the following:

| ID     | Language                | Speakers (Millions) | Voice                |
|--------|-------------------------|---------------------|----------------------|
| af-ZA  | Afrikaans (South Africa)| 7                   | Google.af-ZA-Standard-A |
| eu-ES  | Basque (Spain)          | 0.75                | Google.eu-ES-Standard-A |
| bg-BG  | Bulgarian (Bulgaria)    | 7                   | Google.bg-BG-Standard-A |
| ca-ES  | Catalan (Spain)         | 4.1                 | Polly.Arlet-Neural   |
| cs-CZ  | Czech (Czech Republic)  | 10                  | Google.cs-CZ-Wavenet-A |
| fi-FI  | Finnish (Finland)       | 5                   | Polly.Suvi-Neural    |
| gl-ES  | Galician (Spain)        | 2.4                 | Google.gl-ES-Standard-A |
| el-GR  | Greek (Greece)          | 10.7                | Google.el-GR-Wavenet-A |
| hu-HU  | Hungarian (Hungary)     | 9.8                 | Google.hu-HU-Wavenet-A |
| is-IS  | Icelandic (Iceland)     | 0.34                | Polly.Karl           |
| ro-RO  | Romanian (Romania)      | 24                  | Google.ro-RO-Wavenet-A |
| sr-RS  | Serbian (Cyrillic)      | 6.6                 | Google.sr-RS-Standard-A |
| sk-SK  | Slovak (Slovakia)       | 5                   | Google.sk-SK-Wavenet-A |
| th-TH  | Thai (Thailand)         | 20                  | Google.th-TH-Standard-A |
| uk-UA  | Ukrainian (Ukraine)     | 30                  | Google.uk-UA-Wavenet-A |